### PR TITLE
fix(error-equals): update error equals schemas to have the correct syntax

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "asl-validator",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "asl-validator",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Amazon States Language validator",
   "main": "./src/validator.js",
   "bin": {

--- a/src/__tests__/definitions/invalid-error-equals-type.json
+++ b/src/__tests__/definitions/invalid-error-equals-type.json
@@ -1,0 +1,20 @@
+{
+  "StartAt": "Array items type syntax (Retry, Catch and ErrorEquals) https://github.com/ChristopheBougere/asl-validator/pull/55",
+  "States": {
+    "Testing": {
+      "Type": "Task",
+      "Resource": "arn:aws:lambda:us-west-2:111126812102:function:some-dev-function",
+      "Catch": [{
+        "ErrorEquals": [
+          true
+        ],
+        "Next": "Success"
+      }],
+      "Next": "Success"
+    },
+    "Success": {
+      "Type": "Pass",
+      "End": true
+    }
+  }
+}

--- a/src/schemas/map.json
+++ b/src/schemas/map.json
@@ -41,12 +41,12 @@
     "Retry": {
       "type": "array",
       "items": {
-        "types": "object",
+        "type": "object",
         "properties": {
           "ErrorEquals": {
             "type": "array",
             "items": {
-              "types": "string"
+              "type": "string"
             }
           },
           "IntervalSeconds": {
@@ -68,12 +68,12 @@
     "Catch": {
       "type": "array",
       "items": {
-        "types": "object",
+        "type": "object",
         "properties": {
           "ErrorEquals": {
             "type": "array",
             "items": {
-              "types": "string"
+              "type": "string"
             }
           },
           "Next": {

--- a/src/schemas/parallel.json
+++ b/src/schemas/parallel.json
@@ -34,12 +34,12 @@
     "Retry": {
       "type": "array",
       "items": {
-        "types": "object",
+        "type": "object",
         "properties": {
           "ErrorEquals": {
             "type": "array",
             "items": {
-              "types": "string"
+              "type": "string"
             }
           },
           "IntervalSeconds": {
@@ -61,12 +61,12 @@
     "Catch": {
       "type": "array",
       "items": {
-        "types": "object",
+        "type": "object",
         "properties": {
           "ErrorEquals": {
             "type": "array",
             "items": {
-              "types": "string"
+              "type": "string"
             }
           },
           "Next": {

--- a/src/schemas/task.json
+++ b/src/schemas/task.json
@@ -36,12 +36,12 @@
     "Retry": {
       "type": "array",
       "items": {
-        "types": "object",
+        "type": "object",
         "properties": {
           "ErrorEquals": {
             "type": "array",
             "items": {
-              "types": "string"
+              "type": "string"
             }
           },
           "IntervalSeconds": {
@@ -63,12 +63,12 @@
     "Catch": {
       "type": "array",
       "items": {
-        "types": "object",
+        "type": "object",
         "properties": {
           "ErrorEquals": {
             "type": "array",
             "items": {
-              "types": "string"
+              "type": "string"
             }
           },
           "Next": {


### PR DESCRIPTION
Here is the syntax for declaring `string[]` in json schema: https://json-schema.org/understanding-json-schema/reference/array.html

The current definitions before this change would produce a schema that was an array of objects. `{ [key: string]: any }[]` when used with the https://github.com/bcherny/json-schema-to-typescript package

The current schemas dont seem to be used in the repo anywhere, and definitely not in the tests, so this wouldnt have been caught here. However the downstream package [asl-types](https://www.npmjs.com/package/asl-types) does depend on these schemas, which is where i saw this issue.

I have validated in that package that changing `items` -> `item` did in fact fix the conversion process.

Here is the issue created in that package https://github.com/fourTheorem/asl-types/issues/7

And here are the docs for ErrorEquals https://docs.aws.amazon.com/step-functions/latest/dg/concepts-error-handling.html