### PR TITLE
Fix bug to show missing transition target errors

### DIFF
--- a/src/validator.js
+++ b/src/validator.js
@@ -14,7 +14,8 @@ const checkJsonPath = require('./lib/json-path-errors');
 const missingTransitionTarget = require('./lib/missing-transition-target');
 
 function formatError(e) {
-  return e.Code ? `${e.Code}: ${e.Message}` : e.message;
+  const code = e.Code ?? e['Error code'];
+  return code ? `${code}: ${e.Message}` : e.message;
 }
 
 function validator(definition) {

--- a/src/validator.js
+++ b/src/validator.js
@@ -14,7 +14,7 @@ const checkJsonPath = require('./lib/json-path-errors');
 const missingTransitionTarget = require('./lib/missing-transition-target');
 
 function formatError(e) {
-  const code = e.Code ?? e['Error code'];
+  const code = e.Code ? e.Code : e['Error code'];
   return code ? `${code}: ${e.Message}` : e.message;
 }
 


### PR DESCRIPTION
Missing transition target errors set the properties "Error code" and "Message". The existing formatting logic is based on "Code" and "Message" and will fallback to "message" which isn't set with missing transition target errors, resulting in no error text. This fixes that.

Note: I couldn't find anywhere where "Code" was being used but just to be safe I had it check for both rather than to ONLY look for "Error code".