### PR TITLE
fix schema definition for payload template to avoid the oneOf options intersecting

### DIFF
--- a/src/__tests__/definitions/valid-parameters-issue104.json
+++ b/src/__tests__/definitions/valid-parameters-issue104.json
@@ -1,0 +1,28 @@
+{
+  "StartAt": "Publish to Slack",
+  "States": {
+    "Publish to Slack": {
+      "Type": "Task",
+      "Resource": "arn:aws:lambda:::function:publish-to-slack-lambda",
+      "Parameters": {
+        "slackMessage": {
+          "channel.$": "$.slackErrorChannel",
+          "text.$": "$.slackMessage.title",
+          "blocks": [
+            {
+              "type": "section",
+              "text": {
+                "type": "mrkdwn",
+                "text.$": "$.slackMessage.errorMessage"
+              }
+            }
+          ]
+        }
+      },
+      "Next": "Failure"
+    },
+    "Failure": {
+      "Type": "Fail"
+    }
+  }
+}

--- a/src/__tests__/error-reporting.test.ts
+++ b/src/__tests__/error-reporting.test.ts
@@ -43,8 +43,7 @@ describe("tests with definitions containing errors to see what's reported", () =
                     Message: "/States/Hello, World/Parameters/lorem.$ is invalid. must match format \"asl_payload_template\"",
                     schemaError: {
                         instancePath: "/States/Hello, World/Parameters/lorem.$",
-                        // the regular expression in the path is escaped by AJV when it reports the location of the error
-                        schemaPath: "#/patternProperties/%5E.%2B%5C.%5C%24%24/format"
+                        schemaPath: "#/patternProperties/^.+\\.\\$$/format"
                     }
                 }
             ]

--- a/src/checks/duplicate-payload-template-fields.ts
+++ b/src/checks/duplicate-payload-template-fields.ts
@@ -9,33 +9,40 @@ export const mustNotHaveDuplicateFieldNamesAfterEvaluation: AslChecker = (defini
     // for each one, examine each node's children for field names
     // that will be in conflict after evaluation.
     const errorMessages: StateMachineError[] = [];
-    JSONPath<Record<string, unknown>[]>({
-        json: definition,
-        // this uses some extensions to the original JSONPath spec supported by the lib
-        //
-        // extension 1: @property.match enables matching on the matched property name.
-        //              This finds and selects all nodes with a name ending in .$
-        // extension 2: ^ operator twice at the end selects the parent node instead of the value for the node
-        //
-        // also, don't miss the array offset [0] before selecting the grandparent.
-        // There may be multiple fields within a node that could be in conflict.
-        // We're checking all the keys in the parent node, so we only need a single
-        // result for that parent.
-        path: `$..[Parameters,ResultSelector]..*[?(@property.match(/^.+\\.\\$$/))][0]^^`
-    })
-        .forEach((parent) => {
-            const keys: Record<string, number> = {};
-            Object.keys(parent).forEach((key) => {
-                const keyPostEval = key.endsWith(".$") ? key.substring(0, key.length - 2) : key;
-                const current = keys[keyPostEval];
-                if (current) {
-                    errorMessages.push({
-                        'Error code': StateMachineErrorCode.DuplicateFieldName,
-                        Message: `A duplicate field will exist after renaming to strip the ".$" suffix from: ${key}.$`,
-                    });
-                }
-                keys[keyPostEval] = current ? current + 1 : 1;
-            });
+    let valuesToInspect: Record<string, unknown>[] = [];
+    try {
+        valuesToInspect = JSONPath<Record<string, unknown>[]>({
+            json: definition,
+            // this uses some extensions to the original JSONPath spec supported by the lib
+            //
+            // extension 1: @property.match enables matching on the matched property name.
+            //              This finds and selects all nodes with a name ending in .$
+            // extension 2: ^ operator twice at the end selects the parent node instead of the value for the node
+            //
+            // also, don't miss the array offset [0] before selecting the grandparent.
+            // There may be multiple fields within a node that could be in conflict.
+            // We're checking all the keys in the parent node, so we only need a single
+            // result for that parent.
+            path: `$..[Parameters,ResultSelector]..*[?(@property.match(/^.+\\.\\$$/))][0]^^`
+        })
+    } catch (err: unknown) {
+        // need to revisit this since the JSONPath lib throws an error when it encounters an array
+        // Error: jsonPath: _$_property.match is not a function: _$_property.match(/^.+\.\$$/)
+    }
+
+    valuesToInspect.forEach((parent) => {
+        const keys: Record<string, number> = {};
+        Object.keys(parent).forEach((key) => {
+            const keyPostEval = key.endsWith(".$") ? key.substring(0, key.length - 2) : key;
+            const current = keys[keyPostEval];
+            if (current) {
+                errorMessages.push({
+                    'Error code': StateMachineErrorCode.DuplicateFieldName,
+                    Message: `A duplicate field will exist after renaming to strip the ".$" suffix from: ${key}.$`,
+                });
+            }
+            keys[keyPostEval] = current ? current + 1 : 1;
         });
+    });
     return errorMessages;
 }

--- a/src/checks/json-schema-errors.ts
+++ b/src/checks/json-schema-errors.ts
@@ -93,7 +93,7 @@ export const jsonSchemaErrors: AslChecker = (definition, options) => {
             Message: `${error.instancePath} is invalid. ${error.message ?? ""}`,
             schemaError: {
                 instancePath: error.instancePath,
-                schemaPath: error.schemaPath
+                schemaPath: decodeURIComponent(error.schemaPath)
             }
         }));
 }

--- a/src/schemas/paths.json
+++ b/src/schemas/paths.json
@@ -37,7 +37,7 @@
               }
             },
             {
-              "$ref": "#/definitions/_asl_payload_template"
+              "$ref": "#/definitions/_payload_template_object"
             }
           ]
         }


### PR DESCRIPTION
AJV is failing the input schema since it is matching on two of the available types in its `oneOf` definition. 

closes #104 

fix(schemas): recursive def fixed where oneOf options intersected on array types
fix(check): catch jsonpath error in duplicate-payload-template-fields.ts
refactor(check): decode URI encoded values for cleaner error reporting