### PR TITLE
fix: null is a valid resultpath

### DIFF
--- a/src/__tests__/definitions/valid-null-input.json
+++ b/src/__tests__/definitions/valid-null-input.json
@@ -1,0 +1,15 @@
+{
+    "StartAt": "Hello",
+    "States": {
+        "Hello": {
+            "Type": "Task",
+            "Resource": "arn:aws:lambda:us-east-1:123456789012:function:foo",
+            "InputPath": null,
+            "ResultPath": "$.foo",
+            "Next": "Goodbye"
+        },
+        "Goodbye": {
+            "Type": "Succeed"
+        }
+    }
+}

--- a/src/__tests__/definitions/valid-null-result.json
+++ b/src/__tests__/definitions/valid-null-result.json
@@ -1,0 +1,17 @@
+{
+    "StartAt": "Hello",
+    "States": {
+        "Hello": {
+            "Type": "Task",
+            "Resource": "arn:aws:lambda:us-east-1:123456789012:function:foo",
+            "Parameters": {
+                "foo.$": "$.foo"
+            },
+            "ResultPath": null,
+            "Next": "Goodbye"
+        },
+        "Goodbye": {
+            "Type": "Succeed"
+        }
+    }
+}

--- a/src/schemas/paths.json
+++ b/src/schemas/paths.json
@@ -7,7 +7,7 @@
       "format": "asl_path"
     },
     "asl_ref_path": {
-      "type": "string",
+      "type": ["string", "null"],
       "format": "asl_ref_path"
     },
     "_payload_template_object": {

--- a/src/schemas/paths.json
+++ b/src/schemas/paths.json
@@ -3,7 +3,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "asl_path": {
-      "type": "string",
+      "type": ["string", "null"],
       "format": "asl_path"
     },
     "asl_ref_path": {


### PR DESCRIPTION
Closes #106. Treats a ResultPath of `null` as valid schema. New to the refactored version here so please offer corrections where needed.