### PR TITLE
fix: choice statements must have a Next in first level operators

### DIFF
--- a/src/__tests__/definitions/invalid-choice-state.json
+++ b/src/__tests__/definitions/invalid-choice-state.json
@@ -1,0 +1,20 @@
+{
+  "Comment": "An example showing that choice states are not allowed to go directly to the end of state machine",
+  "StartAt": "ChoiceState",
+  "States": {
+    "ChoiceState": {
+      "Type": "Choice",
+      "Choices": [{
+          "Variable": "$.foo",
+          "NumericEquals": 1,
+          "End": true
+        }
+      ],
+      "Default": "DefaultState"
+    },
+    "DefaultState": {
+      "Type": "Pass",
+      "End": true
+    }
+  }
+}

--- a/src/__tests__/definitions/valid-choice-state.json
+++ b/src/__tests__/definitions/valid-choice-state.json
@@ -15,8 +15,13 @@
           "Next": "FirstMatchState"
         },
         {
-          "Variable": "$.foo",
-          "NumericEquals": 2,
+          "Or": [{
+            "Variable": "$.foo",
+            "NumericEquals": 2
+          }, {
+            "Variable": "$.foo",
+            "NumericEquals": 3
+          }],
           "Next": "SecondMatchState"
         }
       ],

--- a/src/schemas/choice.json
+++ b/src/schemas/choice.json
@@ -8,9 +8,6 @@
         "Variable": {
           "type": "string"
         },
-        "Next": {
-          "type": "string"
-        },
         "And": {
           "type": "array",
           "items": {
@@ -297,7 +294,17 @@
     "Choices": {
       "type": "array",
       "items": {
-        "$ref": "#/definitions/Operator"
+        "allOf": [{
+          "type": "object",
+          "properties": {
+            "Next": {
+              "type": "string"
+            }
+          },
+          "required": ["Next"]
+        }, {
+          "$ref": "#/definitions/Operator"
+        }]
       }
     },
     "Default": {


### PR DESCRIPTION
As described in the [AWS Choice step documentation](https://docs.aws.amazon.com/step-functions/latest/dg/amazon-states-language-choice-state.html)

> Choice states don't support the End field. In addition, they use Next only inside their Choices field.