### PR TITLE
Handle null values in `Parameters` and `ResultSelector`

### DIFF
--- a/src/__tests__/definitions/valid-null-parameter.json
+++ b/src/__tests__/definitions/valid-null-parameter.json
@@ -1,0 +1,16 @@
+{
+    "StartAt": "Hello",
+    "States": {
+        "Hello": {
+            "Type": "Task",
+            "Resource": "arn:aws:lambda:us-east-1:123456789012:function:foo",
+            "Parameters": {
+                "foo": null
+            },
+            "Next": "Goodbye"
+        },
+        "Goodbye": {
+            "Type": "Succeed"
+        }
+    }
+}

--- a/src/__tests__/definitions/valid-null-resultSelector.json
+++ b/src/__tests__/definitions/valid-null-resultSelector.json
@@ -1,0 +1,20 @@
+{
+    "StartAt": "Hello",
+    "States": {
+        "Hello": {
+            "Type": "Task",
+            "Resource": "arn:aws:lambda:us-east-1:123456789012:function:foo",
+            "Parameters": {
+                "foo": "abc"
+            },
+            "ResultSelector": {
+                "absurd": null,
+                "output.$": "$"
+            },
+            "Next": "Goodbye"
+        },
+        "Goodbye": {
+            "Type": "Succeed"
+        }
+    }
+}

--- a/src/checks/duplicate-payload-template-fields.ts
+++ b/src/checks/duplicate-payload-template-fields.ts
@@ -26,7 +26,7 @@ export const mustNotHaveDuplicateFieldNamesAfterEvaluation: AslChecker = (defini
                 });
             }
             keys[keyPostEval] = current ? current + 1 : 1;
-            if (typeof parent[key] === "object") {
+            if (!!parent[key] && typeof parent[key] === "object") {
                 inspectKeys(parent[key] as Record<string, unknown>);
             }
         });


### PR DESCRIPTION
When a `Parameters`/`ResultSelector` block has a `null` value somewhere inside it's identified as an object and so gets checked, resulting in a `TypeError`

Example error before the fix:

```
   TypeError: Cannot convert undefined or null to object
        at Function.keys (<anonymous>)

      17 |     const inspectKeys = (parent: Record<string, unknown>): void => {
      18 |         const keys: Record<string, number> = {};
    > 19 |         Object.keys(parent).forEach((key) => {
         |                ^
      20 |             const keyPostEval = key.endsWith(".$") ? key.substring(0, key.length - 2) : key;
      21 |             const current = keys[keyPostEval];
      22 |             if (current) {
```