### PR TITLE
fix: add checks for timout and time values for task state and wait state

### DIFF
--- a/src/__tests__/definitions/invalid-task-timeout.json
+++ b/src/__tests__/definitions/invalid-task-timeout.json
@@ -1,0 +1,34 @@
+{
+  "Comment": "Example of invalid configuration for TimeoutSeconds and HeartbeatSeconds",
+  "StartAt": "TimeoutSecondsAndTimeoutSecondsPath",
+  "States": {
+    "TimeoutSecondsAndTimeoutSecondsPath": {
+      "Type": "Task",
+      "Resource": "arn:aws:swf:us-east-1:123456789012:task:X",
+      "Parameters": {
+        "flagged": true,
+        "parts": {
+          "first.$": "$.vals[0]",
+          "last3.$": "$.vals[3:]"
+        }
+      },
+      "TimeoutSeconds": 10,
+      "TimeoutSecondsPath": "$.pathToSeconds",
+      "Next": "HeartbeatSecondsAndHeartbeatSecondsPath"
+    },
+    "HeartbeatSecondsAndHeartbeatSecondsPath": {
+      "Type": "Task",
+      "Resource": "arn:aws:swf:us-east-1:123456789012:task:X",
+      "Parameters": {
+        "flagged": true,
+        "parts": {
+          "first.$": "$.vals[0]",
+          "last3.$": "$.vals[3:]"
+        }
+      },
+      "HeartbeatSeconds": 10,
+      "HeartbeatSecondsPath": "$.pathToSeconds",
+      "End": true
+    }
+  }
+}

--- a/src/__tests__/definitions/invalid-wait-state-time.json
+++ b/src/__tests__/definitions/invalid-wait-state-time.json
@@ -1,0 +1,78 @@
+{
+  "Comment": "An example of the Amazon States Language using wait states",
+  "StartAt": "wait_all_time_fields",
+  "States": {
+    "wait_all_time_fields": {
+      "Type": "Wait",
+      "Seconds": 10,
+      "SecondsPath": "$.expiryseconds",
+      "Timestamp": "2015-09-04T01:59:00Z",
+      "TimestampPath": "$.expirydate",
+      "Next": "wait_all_time_fields_without_seconds"
+    },
+    "wait_all_time_fields_without_seconds": {
+      "Type": "Wait",
+      "SecondsPath": "$.expiryseconds",
+      "Timestamp": "2015-09-04T01:59:00Z",
+      "TimestampPath": "$.expirydate",
+      "Next": "wait_all_time_fields_without_seconds_path"
+    },
+    "wait_all_time_fields_without_seconds_path": {
+      "Type": "Wait",
+      "Seconds": 10,
+      "Timestamp": "2015-09-04T01:59:00Z",
+      "TimestampPath": "$.expirydate",
+      "Next": "wait_all_time_fields_without_timestamp"
+    },
+    "wait_all_time_fields_without_timestamp": {
+      "Type": "Wait",
+      "Seconds": 10,
+      "SecondsPath": "$.expiryseconds",
+      "TimestampPath": "$.expirydate",
+      "Next": "wait_all_time_fields_without_timestamp_path"
+    },
+    "wait_all_time_fields_without_timestamp_path": {
+      "Type": "Wait",
+      "Seconds": 10,
+      "SecondsPath": "$.expiryseconds",
+      "Timestamp": "2015-09-04T01:59:00Z",
+      "Next": "wait_both_path_fields"
+    },
+    "wait_both_path_fields": {
+      "Type": "Wait",
+      "SecondsPath": "$.expiryseconds",
+      "TimestampPath": "$.expirydate",
+      "Next": "wait_seconds_timestamp"
+    },
+    "wait_seconds_timestamp": {
+      "Type": "Wait",
+      "Seconds": 10,
+      "Timestamp": "2015-09-04T01:59:00Z",
+      "Next": "wait_seconds_seconds_path"
+    },
+    "wait_seconds_seconds_path": {
+      "Type": "Wait",
+      "Seconds": 10,
+      "SecondsPath": "$.expiryseconds",
+      "Next": "wait_seconds_timestamp_path"
+    },
+    "wait_seconds_timestamp_path": {
+      "Type": "Wait",
+      "Seconds": 10,
+      "TimestampPath": "$.expirydate",
+      "Next": "wait_timestamp_seconds_path"
+    },
+    "wait_timestamp_seconds_path": {
+      "Type": "Wait",
+      "Timestamp": "2015-09-04T01:59:00Z",
+      "SecondsPath": "$.expiryseconds",
+      "Next": "wait_timestamp_timestamp_path"
+    },
+    "wait_timestamp_timestamp_path": {
+      "Type": "Wait",
+      "Timestamp": "2015-09-04T01:59:00Z",
+      "TimestampPath": "$.expirydate",
+      "End": true
+    }
+  }
+}

--- a/src/schemas/task.json
+++ b/src/schemas/task.json
@@ -125,10 +125,30 @@
       "$ref": "paths.json#/definitions/asl_payload_template"
     }
   },
-  "oneOf": [{
-    "required": ["Next"]
+  "allOf": [{
+    "oneOf": [{
+      "required": ["Next"]
+    }, {
+      "required": ["End"]
+    }]
   }, {
-    "required": ["End"]
+    "not": {
+      "allOf": [{
+          "required": ["TimeoutSeconds"]
+        }, {
+          "required": ["TimeoutSecondsPath"]
+        }
+      ]
+    }
+  }, {
+    "not": {
+      "allOf": [{
+         "required": ["HeartbeatSeconds"]
+        }, {
+         "required": ["HeartbeatSecondsPath"]
+        }
+      ]
+    }
   }],
   "required": ["Type", "Resource"],
   "additionalProperties": false

--- a/src/schemas/wait.json
+++ b/src/schemas/wait.json
@@ -36,10 +36,23 @@
       "$ref": "paths.json#/definitions/asl_ref_path"
     }
   },
-  "oneOf": [{
-    "required": ["Next"]
+
+  "allOf": [{
+    "oneOf": [{
+      "required": ["Next"]
+    }, {
+      "required": ["End"]
+    }]
   }, {
-    "required": ["End"]
+    "oneOf": [{
+      "required": ["Seconds"]
+    }, {
+      "required": ["SecondsPath"]
+    }, {
+      "required": ["Timestamp"]
+    }, {
+      "required": ["TimestampPath"]
+    }]
   }],
   "required": ["Type"],
   "additionalProperties": false


### PR DESCRIPTION
The Wait state there is a requirement:
```
A Wait State MUST contain exactly one of "Seconds", "SecondsPath", "Timestamp", or "TimestampPath".
```
The validation is achieved by wrapping both `oneOf` conditions with an `allOf`.

The Task state contains this requirement:
```
A Task State MUST NOT include both "TimeoutSeconds" and "TimeoutSecondsPath" or both "HeartbeatSeconds" and "HeartbeatSecondsPath".
```

The validation is achieved with a combination of `not` and `allOf` conditions to apply a NAND logic for both fields, then wrapped with an `allOf` condition to enforce all conditions to succeed.

One of the tests for error reporting is failing. I tried to debug it, but I don't know the requirements for choosing the correct error to report.