### PR TITLE
refactor: use checker for next end validation instead of schema rule

### DIFF
--- a/src/__tests__/definitions/invalid-next-with-end.json
+++ b/src/__tests__/definitions/invalid-next-with-end.json
@@ -1,0 +1,23 @@
+{
+  "Comment": "Task contains both Next and End property",
+  "StartAt": "Wait for Timestamp",
+  "States": {
+    "Wait for Timestamp": {
+      "Type": "Wait",
+      "TimestampPath": "$.trigger_date",
+      "Next": "Send SNS Message"
+    },
+    "Send SNS Message": {
+      "Type": "Task",
+      "Resource": "arn:aws:lambda:region-1:1234567890:function:SendToSNS",
+      "Retry": [{
+        "ErrorEquals": ["States.ALL"],
+        "IntervalSeconds": 1,
+        "MaxAttempts": 3,
+        "BackoffRate": 2.0
+      }],
+      "Next": "Wait for Timestamp",
+      "End": true
+    }
+  }
+}

--- a/src/checks/get-states.ts
+++ b/src/checks/get-states.ts
@@ -1,0 +1,19 @@
+import {State, StateMachine, States} from "../types";
+import {JSONPath} from "jsonpath-plus";
+
+export const getStatesContainer = (definition: StateMachine) : States[] => {
+    return JSONPath<States[]>({
+        json: definition,
+        path: '$..[\'States\']'
+    })
+}
+
+export const getStates = (states: States): Array<{stateName: string, state: State & {Type: string}}> => {
+    return Object.keys(states).map((stateName) => {
+        const state = states[stateName]
+        return {stateName, state}
+    }).filter(({state}) => {
+        // the schemas will validate if this Type field is valid.
+        return 'Type' in state
+    }).map(({state, stateName}) => { return {stateName, state: state as State & {Type: string}}})
+}

--- a/src/checks/missing-terminal-state-errors.ts
+++ b/src/checks/missing-terminal-state-errors.ts
@@ -1,5 +1,5 @@
-import {JSONPath} from 'jsonpath-plus';
-import {AslChecker, StateMachineError, StateMachineErrorCode, States} from '../types';
+import {AslChecker, StateMachineError, StateMachineErrorCode} from '../types';
+import {getStatesContainer} from "./get-states";
 
 export const missingTerminalStateErrors: AslChecker = (definition) => {
     const errorMessages: StateMachineError[] = [];
@@ -10,14 +10,13 @@ export const missingTerminalStateErrors: AslChecker = (definition) => {
     // - state with Type: Fail
     const terminals: Record<string, number> = {};
     let fsmId = 1;
-    JSONPath<States[]>({json: definition, path: '$..[\'States\']'})
+    getStatesContainer(definition)
         .forEach((states) => {
             const fsmKey = `fsm${fsmId}`;
             // initialize the nested fsm to have a terminal count of zero
             terminals[fsmKey] = 0;
             // check each of its states to see if the fsm terminates
-            Object.keys(states).forEach((stateName) => {
-                const state = states[stateName];
+            Object.values(states).forEach((state) => {
                 const count = terminals[fsmKey];
                 if (['Succeed', 'Fail'].indexOf(state.Type as string) !== -1 || state.End) {
                     terminals[fsmKey] = count ? count + 1 : 1;

--- a/src/checks/terminalStateWithNext.ts
+++ b/src/checks/terminalStateWithNext.ts
@@ -1,0 +1,30 @@
+import {AslChecker, StateMachineError, StateMachineErrorCode} from "../types";
+import {getStates, getStatesContainer} from "./get-states";
+
+// performs the check that non-Terminal states do not contain a `Next` field.
+// This replaces the following schema snippet:
+// "oneOf": [{
+//     "required": ["Next"]
+//   }, {
+//     "required": ["End"]
+//   }],
+export const terminalStateWithNext: AslChecker = (definition) => {
+    const errorMessages: StateMachineError[] = [];
+    getStatesContainer(definition).forEach((states) => {
+        getStates(states).forEach(({stateName, state}) => {
+            // Terminal fields don't need this check
+            if (state.Type === 'Succeed' || state.Type === 'Fail' || state.Type === 'Choice') {
+                return
+            }
+            if ('End' in state && 'Next' in state) {
+                errorMessages.push({
+                    "Error code": StateMachineErrorCode.TerminalStateWithNextError,
+                    // Use of JSONPath within the error message is unnecessary
+                    // since the state names are unique.
+                    Message: `State "${stateName}" contains both "End" and "Next" fields.`,
+                })
+            }
+        })
+    })
+    return errorMessages;
+}

--- a/src/schemas/map.json
+++ b/src/schemas/map.json
@@ -161,26 +161,12 @@
   "oneOf": [
     {
       "required": [
-        "Next",
         "ItemProcessor"
       ]
     },
     {
       "required": [
-        "Next",
         "Iterator"
-      ]
-    },
-    {
-      "required": [
-        "End",
-        "Iterator"
-      ]
-    },
-    {
-      "required": [
-        "End",
-        "ItemProcessor"
       ]
     }
   ],

--- a/src/schemas/parallel.json
+++ b/src/schemas/parallel.json
@@ -86,11 +86,6 @@
       }
     }
   },
-  "oneOf": [{
-    "required": ["Next"]
-  }, {
-    "required": ["End"]
-  }],
   "required": ["Type", "Branches"],
   "additionalProperties": false
 }

--- a/src/schemas/pass.json
+++ b/src/schemas/pass.json
@@ -30,11 +30,6 @@
     },
     "Result": {}
   },
-  "oneOf": [{
-    "required": ["Next"]
-  }, {
-    "required": ["End"]
-  }],
   "required": ["Type"],
   "additionalProperties": false
 }

--- a/src/schemas/task.json
+++ b/src/schemas/task.json
@@ -125,11 +125,6 @@
       "$ref": "paths.json#/definitions/asl_payload_template"
     }
   },
-  "oneOf": [{
-    "required": ["Next"]
-  }, {
-    "required": ["End"]
-  }],
   "required": ["Type", "Resource"],
   "additionalProperties": false
 }

--- a/src/schemas/wait.json
+++ b/src/schemas/wait.json
@@ -36,11 +36,6 @@
       "$ref": "paths.json#/definitions/asl_ref_path"
     }
   },
-  "oneOf": [{
-    "required": ["Next"]
-  }, {
-    "required": ["End"]
-  }],
   "required": ["Type"],
   "additionalProperties": false
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,7 @@ export enum StateMachineErrorCode {
   MissingTerminalState = 'MISSING_TERMINAL_STATE',
   MissingTransitionTarget = 'MISSING_TRANSITION_TARGET',
   SchemaValidationFailed = 'SCHEMA_VALIDATION_FAILED',
+  TerminalStateWithNextError = 'TERMINAL_STATE_WITH_NEXT',
 }
 export type StateMachineError = {
   'Error code': StateMachineErrorCode;

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -7,6 +7,7 @@ import {duplicateStateNames} from './checks/duplicate-state-names-errors';
 import {missingTerminalStateErrors} from './checks/missing-terminal-state-errors';
 import {StateMachine, StateMachineError, ValidationOptions} from './types';
 import {mustNotHaveDuplicateFieldNamesAfterEvaluation} from "./checks/duplicate-payload-template-fields";
+import {terminalStateWithNext} from "./checks/terminalStateWithNext";
 
 const DefaultOptions: ValidationOptions = {
     checkPaths: true,
@@ -26,6 +27,7 @@ export = function validator(definition: StateMachine, opts?: ValidationOptions):
         errors.push(...duplicateStateNames(definition, options));
         errors.push(...missingTerminalStateErrors(definition, options));
         errors.push(...mustNotHaveDuplicateFieldNamesAfterEvaluation(definition, options))
+        errors.push(...terminalStateWithNext(definition, options));
     }
 
     return {


### PR DESCRIPTION
See the discussion #119 

This replaces the JSON rules for `Next` and `End` with a typescript function. The purpose is to improve the error messages and set a pattern for a few other mutually exclusive properties. The new ones for `Map` plus existing ones like TimeSeconds and TimeSecondsPath.
