### PR TITLE
chore: remove unused definition in paths

### DIFF
--- a/src/schemas/paths.json
+++ b/src/schemas/paths.json
@@ -58,19 +58,6 @@
           "type": ["string", "boolean", "number"]
         }
       ]
-    },
-    "_asl_payload_template": {
-      "oneOf": [
-        {
-          "$ref": "#/definitions/_payload_template_object"
-        },
-        {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/_asl_payload_template"
-          }
-        }
-      ]
     }
   }
 }


### PR DESCRIPTION
Small PR to remove an unused definition from the schema. This was spotted in a recent issue a few weeks back.