### PR TITLE
fix: typo in map schema for tolerated failure prop

### DIFF
--- a/src/__tests__/definitions/invalid-map-distributed.asl.json
+++ b/src/__tests__/definitions/invalid-map-distributed.asl.json
@@ -1,5 +1,5 @@
 {
-  "Comment": "Using Map state in Distributed mode",
+  "Comment": "Invalid item reader with both MaxItems and MaxItemsPath defined",
   "StartAt": "Map",
   "States": {
     "Map": {
@@ -8,7 +8,8 @@
         "ReaderConfig": {
           "InputType": "CSV",
           "CSVHeaderLocation": "FIRST_ROW",
-          "MaxItems": 1
+          "MaxItems": 1,
+          "MaxItemsPath": "$.foo"
         },
         "Resource": "arn:aws:states:::s3:getObject",
         "Parameters": {

--- a/src/schemas/map.json
+++ b/src/schemas/map.json
@@ -35,9 +35,39 @@
       "type": "number",
       "minimum": 0
     },
+    "MaxConcurrencyPath": {
+      "$ref": "paths.json#/definitions/asl_ref_path"
+    },
     "ItemReader": {
-      "$comment": "Allow any object for now and update in a subsequent PR to support S3 buckets and other input sources",
-      "type": "object"
+      "$comment": "A Map State MAY have an \"ItemReader\" field, whose value MUST be a JSON object and is called the ItemReader Configuration",
+      "type": "object",
+      "properties": {
+        "Resource": {
+          "$comment": "The ItemReader Configuration MUST have a \"Resource\" field, whose value MUST be a URI that uniquely identifies the specific task to execute. The States language does not constrain the URI scheme nor any other part of the URI.",
+          "type": "string"
+        },
+        "Parameters": {
+          "$comment": "The ItemReader Configuration MAY have a \"Parameters\" field, whose value MUST be a Payload Template.",
+          "$ref": "paths.json#/definitions/asl_payload_template"
+        },
+        "ReaderConfig": {
+          "$comment": "The ItemReader Configuration MAY have a \"ReaderConfig\" field whose value is a JSON object which MAY have a \"MaxItems\" field which MUST be a positive integer.",
+          "type": "object",
+          "properties": {
+            "MaxItems": {
+              "$comment": "MAY have a \"MaxItems\" field which MUST be a positive integer",
+              "type": "integer",
+              "minimum": 1
+            },
+            "MaxItemsPath": {
+              "$comment": "A \"ReaderConfig\" field MAY have \"MaxItemsPath\" field which MUST be a Reference Path which, when resolved, MUST select a field whose value is a positive integer.",
+              "$ref": "paths.json#/definitions/asl_ref_path"
+            }
+          },
+          "additionalProperties": true
+        }
+      },
+      "required": ["Resource"]
     },
     "ItemProcessor": {
       "type": "object",
@@ -161,7 +191,7 @@
       "type": "integer",
       "minimum": 0
     },
-    "ToleratedFailurePath": {
+    "ToleratedFailureCountPath": {
       "$ref": "paths.json#/definitions/asl_ref_path"
     },
     "ToleratedFailurePercentage": {

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,8 @@ export enum StateMachineErrorCode {
   MapItemProcessorError = 'MAP_ITEM_PROCESSOR',
   MapItemSelectorError = 'MAP_ITEM_SELECTOR',
   MapToleratedFailureError = 'MAP_TOLERATED_FAILURE',
+  MapMaxConcurrencyError = 'MAP_CONCURRENCY_ERROR',
+  MapItemReaderMaxItemsError = 'MAP_ITEMREADER_MAXITEM'
 }
 export type StateMachineError = {
   'Error code': StateMachineErrorCode;

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -95,6 +95,21 @@ export = function validator(definition: StateMachine, opts?: ValidationOptions):
                     props: ["ToleratedFailurePercentage", "ToleratedFailurePercentagePath"],
                     errorCode: StateMachineErrorCode.MapToleratedFailureError})
             },
+            {
+                filter: IsMap,
+                checker: AtMostOne({
+                    props: ["MaxConcurrency", "MaxConcurrencyPath"],
+                    errorCode: StateMachineErrorCode.MapMaxConcurrencyError
+                })
+            },
+            {
+                filter: IsMap,
+                checker: AtMostOne({
+                    props: ["MaxItems", "MaxItemsPath"],
+                    path: "$.ItemReader.ReaderConfig",
+                    errorCode: StateMachineErrorCode.MapItemReaderMaxItemsError
+                })
+            },
         ]))
     }
 


### PR DESCRIPTION
fix: report at most one error for max items props
feat: encode some item reader and reader config rules in map schema