### PR TITLE
Bugfix/130 item batcher validation

### DIFF
--- a/src/__tests__/definitions/invalid-map-item-batcher-dupe-subfields.json
+++ b/src/__tests__/definitions/invalid-map-item-batcher-dupe-subfields.json
@@ -1,0 +1,36 @@
+{
+  "Comment": "ItemBatcher can specify batchSize or path but not both",
+  "StartAt": "Map",
+  "States": {
+    "Map": {
+      "Type": "Map",
+      "ItemBatcher": {
+        "MaxItemsPerBatch": 2,
+        "MaxItemsPerBatchPath": "$.batchByes",
+        "MaxInputBytesPerBatch": 131072,
+        "MaxInputBytesPerBatchPath": "$.batchByes"
+      },
+      "ItemProcessor": {
+        "ProcessorConfig": {
+          "Mode": "DISTRIBUTED",
+          "ExecutionType": "EXPRESS"
+        },
+        "StartAt": "LambdaTask",
+        "States": {
+          "LambdaTask": {
+            "Type": "Task",
+            "Resource": "arn:aws:states:::lambda:invoke",
+            "OutputPath": "$.Payload",
+            "Parameters": {
+              "Payload.$": "$",
+              "FunctionName": "arn:aws:lambda:us-east-2:123456789012:function:processCSVData"
+            },
+            "End": true
+          }
+        }
+      },
+      "Label": "Map",
+      "End": true
+    }
+  }
+}

--- a/src/__tests__/definitions/valid-map-with-item-batcher.json
+++ b/src/__tests__/definitions/valid-map-with-item-batcher.json
@@ -1,0 +1,37 @@
+{
+  "Comment": "ItemBatcher can specify batchSize or path but not both",
+  "StartAt": "Map",
+  "States": {
+    "Map": {
+      "Type": "Map",
+      "ItemBatcher": {
+        "MaxItemsPerBatch": 2,
+        "MaxInputBytesPerBatch": 131072,
+        "BatchInput": {
+          "inputKey": "inputValue"
+        }
+      },
+      "ItemProcessor": {
+        "ProcessorConfig": {
+          "Mode": "DISTRIBUTED",
+          "ExecutionType": "EXPRESS"
+        },
+        "StartAt": "LambdaTask",
+        "States": {
+          "LambdaTask": {
+            "Type": "Task",
+            "Resource": "arn:aws:states:::lambda:invoke",
+            "OutputPath": "$.Payload",
+            "Parameters": {
+              "Payload.$": "$",
+              "FunctionName": "arn:aws:lambda:us-east-2:123456789012:function:processCSVData"
+            },
+            "End": true
+          }
+        }
+      },
+      "Label": "Map",
+      "End": true
+    }
+  }
+}

--- a/src/schemas/map.json
+++ b/src/schemas/map.json
@@ -114,26 +114,28 @@
     "ItemSelector": {
       "$ref": "paths.json#/definitions/asl_payload_template"
     },
-    "ItemBatcher":{
+    "ItemBatcher": {
       "type": "object",
-      "oneOf": [
-        {
-          "type": "object",
-          "properties": {
-            "MaxItemsPerBatch": {
-              "type": "number"
-            }
-          }
+      "properties": {
+        "MaxItemsPerBatch": {
+          "type": "number",
+          "minimum": 0
         },
-        {
-          "type": "object",
-          "properties": {
-            "MaxItemsPerBatchPath": {
-              "$ref": "paths.json#/definitions/asl_ref_path"
-            }
-          }
+        "MaxItemsPerBatchPath": {
+          "$ref": "paths.json#/definitions/asl_ref_path"
+        },
+        "MaxInputBytesPerBatch": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 262144
+        },
+        "MaxInputBytesPerBatchPath": {
+          "$ref": "paths.json#/definitions/asl_ref_path"
+        },
+        "BatchInput": {
+          "$ref": "paths.json#/definitions/asl_payload_template"
         }
-      ]
+      }
     },
     "ResultSelector": {
       "$ref": "paths.json#/definitions/asl_payload_template"

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,7 @@ export enum StateMachineErrorCode {
   TaskHeartbeatError = 'TASK_HEARTBEAT',
   MapItemProcessorError = 'MAP_ITEM_PROCESSOR',
   MapItemSelectorError = 'MAP_ITEM_SELECTOR',
+  MapItemBatcherError = 'MAP_ITEM_BATCHER',
   MapToleratedFailureError = 'MAP_TOLERATED_FAILURE',
   MapMaxConcurrencyError = 'MAP_CONCURRENCY_ERROR',
   MapItemReaderMaxItemsError = 'MAP_ITEMREADER_MAXITEM'

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -115,14 +115,14 @@ export = function validator(definition: StateMachine, opts?: ValidationOptions):
                 checker: AtMostOne({
                     props: ["MaxItemsPerBatch", "MaxItemsPerBatchPath"],
                     path: "$.ItemBatcher",
-                    errorCode: StateMachineErrorCode.MapItemSelectorError})
+                    errorCode: StateMachineErrorCode.MapItemBatcherError})
             },
             {
                 filter: IsMap,
                 checker: AtMostOne({
                     props: ["MaxInputBytesPerBatch", "MaxInputBytesPerBatchPath"],
                     path: "$.ItemBatcher",
-                    errorCode: StateMachineErrorCode.MapItemSelectorError})
+                    errorCode: StateMachineErrorCode.MapItemBatcherError})
             },
         ]))
     }

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -110,6 +110,20 @@ export = function validator(definition: StateMachine, opts?: ValidationOptions):
                     errorCode: StateMachineErrorCode.MapItemReaderMaxItemsError
                 })
             },
+            {
+                filter: IsMap,
+                checker: AtMostOne({
+                    props: ["MaxItemsPerBatch", "MaxItemsPerBatchPath"],
+                    path: "$.ItemBatcher",
+                    errorCode: StateMachineErrorCode.MapItemSelectorError})
+            },
+            {
+                filter: IsMap,
+                checker: AtMostOne({
+                    props: ["MaxInputBytesPerBatch", "MaxInputBytesPerBatchPath"],
+                    path: "$.ItemBatcher",
+                    errorCode: StateMachineErrorCode.MapItemSelectorError})
+            },
         ]))
     }
 


### PR DESCRIPTION
I made a mess of the rebase on the old PR (https://github.com/ChristopheBougere/asl-validator/pull/131), so this is a clean implementation using the `path` property to specify nested items.