### PR TITLE
fix: semantics for item processor

### DIFF
--- a/src/__tests__/definitions/valid-map-noconfig.asl.json
+++ b/src/__tests__/definitions/valid-map-noconfig.asl.json
@@ -1,0 +1,45 @@
+{
+  "Comment": "Valid example of Map without ProcessorConfig",
+  "StartAt": "Map",
+  "States": {
+    "Map": {
+      "Type": "Map",
+      "ItemReader": {
+        "ReaderConfig": {
+          "InputType": "CSV",
+          "CSVHeaderLocation": "FIRST_ROW",
+          "MaxItems": 1
+        },
+        "Resource": "arn:aws:states:::s3:getObject",
+        "Parameters": {
+          "Bucket": "Database",
+          "Key": "csv-dataset/ratings.csv"
+        }
+      },
+      "ItemProcessor": {
+        "StartAt": "LambdaTask",
+        "States": {
+          "LambdaTask": {
+            "Type": "Task",
+            "Resource": "arn:aws:states:::lambda:invoke",
+            "OutputPath": "$.Payload",
+            "Parameters": {
+              "Payload.$": "$",
+              "FunctionName": "arn:aws:lambda:us-east-2:123456789012:function:processCSVData"
+            },
+            "End": true
+          }
+        }
+      },
+      "Label": "Map",
+      "End": true,
+      "ResultWriter": {
+        "Resource": "arn:aws:states:::s3:putObject",
+        "Parameters": {
+          "Bucket": "myOutputBucket",
+          "Prefix": "csvProcessJobs"
+        }
+      }
+    }
+  }
+}

--- a/src/schemas/map.json
+++ b/src/schemas/map.json
@@ -72,24 +72,21 @@
     "ItemProcessor": {
       "type": "object",
       "allOf": [{ "$ref": "base-state-machine.json#" }],
-      "oneOf": [
-        {
-          "properties": {
-            "ProcessorConfig": {
-              "type": "object",
+      "$comment": "The \"ItemProcessor\" field MAY contain a field named \"ProcessorConfig\", whose value MUST be a JSON object whose value is defined by the interpreter.",
+      "properties": {
+        "ProcessorConfig": {
+          "type": "object",
+          "oneOf": [
+            {
               "properties": {
                 "Mode": {
                   "type": "string",
                   "enum": ["INLINE"]
                 }
-              }
-            }
-          }
-        },
-        {
-          "properties": {
-            "ProcessorConfig": {
-              "type": "object",
+              },
+              "required": ["Mode"]
+            },
+            {
               "properties": {
                 "Mode": {
                   "type": "string",
@@ -99,11 +96,12 @@
                   "type": "string",
                   "enum": ["EXPRESS", "STANDARD"]
                 }
-              }
+              },
+              "required": ["Mode", "ExecutionType"]
             }
-          }
+          ]
         }
-      ]
+      }
     },
     "Iterator": {
       "$ref": "base-state-machine.json#"


### PR DESCRIPTION
This closes #135 

I added a test to recreate the failure and then modified the map's schema. The previous definition looked ok but evidently resulted in the field being required.

This change moves the `oneOf` into the ProcessorConfig definition (still not a required field). The options for the `oneOf` enumerate the two valid configs defined by AWS