### PR TITLE
fix: set choice state variable and path fields set to reference paths

### DIFF
--- a/src/__tests__/definitions/invalid-choice-state-variable.json
+++ b/src/__tests__/definitions/invalid-choice-state-variable.json
@@ -1,0 +1,27 @@
+{
+  "Comment": "Violates the rule: The values of Variable and Path fields in a comparison must be valid Reference Paths.",
+  "StartAt": "ChoiceState",
+  "States": {
+    "ChoiceState": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Variable": "States.ArrayContains($.clients.unique, 'null')",
+          "NumericEquals": 1,
+          "Next": "FirstMatchState"
+        }
+      ],
+      "Default": "DefaultState"
+    },
+
+    "FirstMatchState": {
+      "Type": "Pass",
+      "End": true
+    },
+
+    "DefaultState": {
+      "Type": "Pass",
+      "End": true
+    }
+  }
+}

--- a/src/schemas/choice.json
+++ b/src/schemas/choice.json
@@ -6,7 +6,7 @@
       "type": "object",
       "properties": {
         "Variable": {
-          "type": "string"
+          "$ref": "paths.json#/definitions/asl_ref_path"
         },
         "And": {
           "type": "array",
@@ -33,7 +33,7 @@
           "type": "boolean"
         },
         "BooleanEqualsPath": {
-          "$ref": "paths.json#/definitions/asl_path"
+          "$ref": "paths.json#/definitions/asl_ref_path"
         },
         "IsBoolean": {
           "type": "boolean"
@@ -42,31 +42,31 @@
           "type": "number"
         },
         "NumericEqualsPath": {
-          "$ref": "paths.json#/definitions/asl_path"
+          "$ref": "paths.json#/definitions/asl_ref_path"
         },
         "NumericGreaterThan": {
           "type": "number"
         },
         "NumericGreaterThanPath": {
-          "$ref": "paths.json#/definitions/asl_path"
+          "$ref": "paths.json#/definitions/asl_ref_path"
         },
         "NumericGreaterThanEquals": {
           "type": "number"
         },
         "NumericGreaterThanEqualsPath": {
-          "$ref": "paths.json#/definitions/asl_path"
+          "$ref": "paths.json#/definitions/asl_ref_path"
         },
         "NumericLessThan": {
           "type": "number"
         },
         "NumericLessThanPath": {
-          "$ref": "paths.json#/definitions/asl_path"
+          "$ref": "paths.json#/definitions/asl_ref_path"
         },
         "NumericLessThanEquals": {
           "type": "number"
         },
         "NumericLessThanEqualsPath": {
-          "$ref": "paths.json#/definitions/asl_path"
+          "$ref": "paths.json#/definitions/asl_ref_path"
         },
         "IsNumeric": {
           "type": "boolean"
@@ -75,31 +75,31 @@
           "type": "string"
         },
         "StringEqualsPath": {
-          "$ref": "paths.json#/definitions/asl_path"
+          "$ref": "paths.json#/definitions/asl_ref_path"
         },
         "StringGreaterThan": {
           "type": "string"
         },
         "StringGreaterThanPath": {
-          "$ref": "paths.json#/definitions/asl_path"
+          "$ref": "paths.json#/definitions/asl_ref_path"
         },
         "StringGreaterThanEquals": {
           "type": "string"
         },
         "StringGreaterThanEqualsPath": {
-          "$ref": "paths.json#/definitions/asl_path"
+          "$ref": "paths.json#/definitions/asl_ref_path"
         },
         "StringLessThan": {
           "type": "string"
         },
         "StringLessThanPath": {
-          "$ref": "paths.json#/definitions/asl_path"
+          "$ref": "paths.json#/definitions/asl_ref_path"
         },
         "StringLessThanEquals": {
           "type": "string"
         },
         "StringLessThanEqualsPath": {
-          "$ref": "paths.json#/definitions/asl_path"
+          "$ref": "paths.json#/definitions/asl_ref_path"
         },
         "StringMatches": {
           "type": "string"
@@ -111,31 +111,31 @@
           "type": "string"
         },
         "TimestampEqualsPath": {
-          "$ref": "paths.json#/definitions/asl_path"
+          "$ref": "paths.json#/definitions/asl_ref_path"
         },
         "TimestampGreaterThan": {
           "type": "string"
         },
         "TimestampGreaterThanPath": {
-          "$ref": "paths.json#/definitions/asl_path"
+          "$ref": "paths.json#/definitions/asl_ref_path"
         },
         "TimestampGreaterThanEquals": {
           "type": "string"
         },
         "TimestampGreaterThanEqualsPath": {
-          "$ref": "paths.json#/definitions/asl_path"
+          "$ref": "paths.json#/definitions/asl_ref_path"
         },
         "TimestampLessThan": {
           "type": "string"
         },
         "TimestampLessThanPath": {
-          "$ref": "paths.json#/definitions/asl_path"
+          "$ref": "paths.json#/definitions/asl_ref_path"
         },
         "TimestampLessThanEquals": {
           "type": "string"
         },
         "TimestampLessThanEqualsPath": {
-          "$ref": "paths.json#/definitions/asl_path"
+          "$ref": "paths.json#/definitions/asl_ref_path"
         },
         "IsTimestamp": {
           "type": "boolean"


### PR DESCRIPTION
This was a miss when I added the validation for the path expressions. 

From the [spec](https://docs.aws.amazon.com/step-functions/latest/dg/amazon-states-language-choice-state.html) for the Choice state: 

>The values of Variable and Path fields in a comparison must be valid [Reference Paths](https://docs.aws.amazon.com/step-functions/latest/dg/amazon-states-language-paths.html#amazon-states-language-reference-paths).

Small change to update the schema and provide a test for the negative case.

closes #144 