### PR TITLE
fix: support path fields on fail for cause and error

### DIFF
--- a/src/__tests__/definitions/invalid-fail-dupe-cause.json
+++ b/src/__tests__/definitions/invalid-fail-dupe-cause.json
@@ -1,10 +1,11 @@
 {
-  "Comment": "Contrived example with a Fail state to show it satisfies the terminal state requirement",
+  "Comment": "Contains both Cause and CausePath when only one is allowed",
   "StartAt": "Hello",
   "States": {
     "Hello": {
       "Type": "Fail",
       "Cause": "CauseExample",
+      "CausePath": "$.cause",
       "Error": "ErrorExample"
     }
   }

--- a/src/__tests__/definitions/invalid-fail-dupe-error.json
+++ b/src/__tests__/definitions/invalid-fail-dupe-error.json
@@ -1,0 +1,11 @@
+{
+  "Comment": "Contains both Error and ErrorPath when only one is allowed",
+  "StartAt": "Hello",
+  "States": {
+    "Hello": {
+      "Type": "Fail",
+      "Error": "CauseExample",
+      "ErrorPath": "$.error"
+    }
+  }
+}

--- a/src/__tests__/definitions/valid-fail-paths.json
+++ b/src/__tests__/definitions/valid-fail-paths.json
@@ -4,8 +4,8 @@
   "States": {
     "Hello": {
       "Type": "Fail",
-      "Cause": "CauseExample",
-      "Error": "ErrorExample"
+      "CausePath": "$.path",
+      "ErrorPath": "States.Format('{}{}', $.field1, $field2)"
     }
   }
 }

--- a/src/schemas/fail.json
+++ b/src/schemas/fail.json
@@ -13,7 +13,15 @@
     "Cause": {
       "type": "string"
     },
+    "CausePath": {
+      "$comment": "This field is a ReferencePath with limited Intrinsic Function support. Using string until custom validation is available.",
+      "type": "string"
+    },
     "Error": {
+      "type": "string"
+    },
+    "ErrorPath": {
+      "$comment": "This field is a ReferencePath with limited Intrinsic Function support. Using string until custom validation is available.",
       "type": "string"
     }
   },

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,8 @@ export enum StateMachineErrorCode {
   MapToleratedFailureError = "MAP_TOLERATED_FAILURE",
   MapMaxConcurrencyError = "MAP_CONCURRENCY_ERROR",
   MapItemReaderMaxItemsError = "MAP_ITEMREADER_MAXITEM",
+  FailCauseProperty = "FAIL_CAUSE_PROPERTY",
+  FailErrorProperty = "FAIL_ERROR_PROPERTY",
 }
 export type StateMachineError = {
   "Error code": StateMachineErrorCode;

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -148,6 +148,20 @@ export = function validator(
             errorCode: StateMachineErrorCode.MapItemBatcherError,
           }),
         },
+        {
+          filter: IsFail,
+          checker: AtMostOne({
+            props: ["Cause", "CausePath"],
+            errorCode: StateMachineErrorCode.FailCauseProperty,
+          }),
+        },
+        {
+          filter: IsFail,
+          checker: AtMostOne({
+            props: ["Error", "ErrorPath"],
+            errorCode: StateMachineErrorCode.FailErrorProperty,
+          }),
+        },
       ])
     );
   }


### PR DESCRIPTION
This is a partial fix for the issue. I added support for the two new fields but typed them as a `string` since the existing validators for the ASL paths don't support the custom logic needed to accept a Reference Path and subset of Intrinsic Functions

This at least unblocks the use of the fields. 