### PR TITLE
fix: bump version of path validator to support current value expr

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.12.0",
-        "asl-path-validator": "^0.12.0",
+        "asl-path-validator": "^0.13.0",
         "commander": "^10.0.1",
         "jsonpath-plus": "^7.2.0",
         "yaml": "^2.3.1"
@@ -2789,9 +2789,9 @@
       }
     },
     "node_modules/asl-path-validator": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/asl-path-validator/-/asl-path-validator-0.12.0.tgz",
-      "integrity": "sha512-pzBX2mKp8NQ7p1xM6sfSd2vFQJDX0UdUCun/YcRKMNSv7j93erTomK7iIU79N5rjJD++kPr9qwWhA67pFVpdhA==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/asl-path-validator/-/asl-path-validator-0.13.0.tgz",
+      "integrity": "sha512-A1me0H6HFBIm4b1p3gtSL2N0rMxK0yCz/5YAIpeQixhIMaSQynjKCS+3Q7NNdI/K8sjGe12nU3RrJ77RKtvQYA==",
       "dependencies": {
         "jsonpath-plus": "^7.0.0"
       }
@@ -14555,9 +14555,9 @@
       "dev": true
     },
     "asl-path-validator": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/asl-path-validator/-/asl-path-validator-0.12.0.tgz",
-      "integrity": "sha512-pzBX2mKp8NQ7p1xM6sfSd2vFQJDX0UdUCun/YcRKMNSv7j93erTomK7iIU79N5rjJD++kPr9qwWhA67pFVpdhA==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/asl-path-validator/-/asl-path-validator-0.13.0.tgz",
+      "integrity": "sha512-A1me0H6HFBIm4b1p3gtSL2N0rMxK0yCz/5YAIpeQixhIMaSQynjKCS+3Q7NNdI/K8sjGe12nU3RrJ77RKtvQYA==",
       "requires": {
         "jsonpath-plus": "^7.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "homepage": "https://github.com/ChristopheBougere/asl-validator#readme",
   "dependencies": {
     "ajv": "^8.12.0",
-    "asl-path-validator": "^0.12.0",
+    "asl-path-validator": "^0.13.0",
     "commander": "^10.0.1",
     "jsonpath-plus": "^7.2.0",
     "yaml": "^2.3.1"

--- a/src/__tests__/definitions/valid-current-value-predicate.json
+++ b/src/__tests__/definitions/valid-current-value-predicate.json
@@ -1,0 +1,40 @@
+{
+  "StartAt": "Mock Service Catalog Describe Record",
+  "States": {
+    "Mock Service Catalog Describe Record": {
+      "Type": "Pass",
+      "Parameters": {
+        "DescribeRecord": {
+          "RecordDetail": {
+            "RecordId": "rec-abcdefghijklm",
+            "Status": "SUCCEEDED",
+            "COMMENT": "there are more properties, limited for brevity"
+          },
+          "RecordOutputs": [
+            {
+              "Description": "Foo Bar",
+              "OutputKey": "FooBar",
+              "OutputValue": "0123456789"
+            },
+            {
+              "Description": "Fizz Buzz",
+              "OutputKey": "FizzBuzz",
+              "OutputValue": "fizzbuzz@example.com"
+            }
+          ]
+        }
+      },
+      "ResultPath": "$",
+      "Next": "Get Record Outputs"
+    },
+    "Get Record Outputs": {
+      "Type": "Pass",
+      "Parameters": {
+        "FooBar.$": "States.ArrayGetItem($.DescribeRecord.RecordOutputs[?(@.OutputKey == FooBar)].OutputValue, 0)",
+        "FizzBuzz.$": "States.ArrayGetItem($.DescribeRecord.RecordOutputs[?(@.OutputKey == FizzBuzz)].OutputValue, 0)"
+      },
+      "ResultPath": "$",
+      "End": true
+    }
+  }
+}


### PR DESCRIPTION
closes #150 

The expression validator didn't support the construct of a predicate with the current value operator (`@`). I fixed this in that repo and I'm bumping the version here to use the latest. 

Here's the relevant part of the grammar that changed:
https://github.com/massfords/asl-path-validator/blob/main/src/aslPaths.pegjs#L89-L102

Note the addition of the new rule `predicate` which allows for the current value operator to be used in a comparison expression

It's also worth noting that AWS has since made reference to the official JSONPath specification in their docs which has its own grammar so adopting that grammar in place of my peg solution is something to look at when there's time