### PR TITLE
chore: bump jsonpath-plus to 10.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "ajv": "^8.12.0",
         "asl-path-validator": "^0.15.0",
         "commander": "^10.0.1",
-        "jsonpath-plus": "^10.0.0",
+        "jsonpath-plus": "^10.2.0",
         "yaml": "^2.3.1"
       },
       "bin": {
@@ -1481,9 +1481,9 @@
       }
     },
     "node_modules/@jsep-plugin/assignment": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.2.1.tgz",
-      "integrity": "sha512-gaHqbubTi29aZpVbBlECRpmdia+L5/lh2BwtIJTmtxdbecEyyX/ejAOg7eQDGNvGOUmPY7Z2Yxdy9ioyH/VJeA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.3.0.tgz",
+      "integrity": "sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 10.16.0"
@@ -1493,9 +1493,9 @@
       }
     },
     "node_modules/@jsep-plugin/regex": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.3.tgz",
-      "integrity": "sha512-XfZgry4DwEZvSFtS/6Y+R48D7qJYJK6R9/yJFyUFHCIUMEEHuJ4X95TDgJp5QkmzfLYvapMPzskV5HpIDrREug==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.4.tgz",
+      "integrity": "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==",
       "license": "MIT",
       "engines": {
         "node": ">= 10.16.0"
@@ -6118,9 +6118,9 @@
       }
     },
     "node_modules/jsep": {
-      "version": "1.3.9",
-      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.3.9.tgz",
-      "integrity": "sha512-i1rBX5N7VPl0eYb6+mHNp52sEuaS2Wi8CDYx1X5sn9naevL78+265XJqy1qENEk7mRKwS06NHpUqiBwR7qeodw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
+      "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "license": "MIT",
       "engines": {
         "node": ">= 10.16.0"
@@ -6202,13 +6202,14 @@
       ]
     },
     "node_modules/jsonpath-plus": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.1.0.tgz",
-      "integrity": "sha512-gHfV1IYqH8uJHYVTs8BJX1XKy2/rR93+f8QQi0xhx95aCiXn1ettYAd5T+7FU6wfqyDoX/wy0pm/fL3jOKJ9Lg==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.2.0.tgz",
+      "integrity": "sha512-T9V+8iNYKFL2n2rF+w02LBOT2JjDnTjioaNFrxRy0Bv1y/hNsqR/EBK7Ojy2ythRHwmz2cRIls+9JitQGZC/sw==",
+      "license": "MIT",
       "dependencies": {
-        "@jsep-plugin/assignment": "^1.2.1",
-        "@jsep-plugin/regex": "^1.0.3",
-        "jsep": "^1.3.9"
+        "@jsep-plugin/assignment": "^1.3.0",
+        "@jsep-plugin/regex": "^1.0.4",
+        "jsep": "^1.4.0"
       },
       "bin": {
         "jsonpath": "bin/jsonpath-cli.js",
@@ -13890,15 +13891,15 @@
       }
     },
     "@jsep-plugin/assignment": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.2.1.tgz",
-      "integrity": "sha512-gaHqbubTi29aZpVbBlECRpmdia+L5/lh2BwtIJTmtxdbecEyyX/ejAOg7eQDGNvGOUmPY7Z2Yxdy9ioyH/VJeA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.3.0.tgz",
+      "integrity": "sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==",
       "requires": {}
     },
     "@jsep-plugin/regex": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.3.tgz",
-      "integrity": "sha512-XfZgry4DwEZvSFtS/6Y+R48D7qJYJK6R9/yJFyUFHCIUMEEHuJ4X95TDgJp5QkmzfLYvapMPzskV5HpIDrREug==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.4.tgz",
+      "integrity": "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==",
       "requires": {}
     },
     "@nodelib/fs.scandir": {
@@ -17263,9 +17264,9 @@
       }
     },
     "jsep": {
-      "version": "1.3.9",
-      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.3.9.tgz",
-      "integrity": "sha512-i1rBX5N7VPl0eYb6+mHNp52sEuaS2Wi8CDYx1X5sn9naevL78+265XJqy1qENEk7mRKwS06NHpUqiBwR7qeodw=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
+      "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw=="
     },
     "jsesc": {
       "version": "3.0.2",
@@ -17325,13 +17326,13 @@
       "dev": true
     },
     "jsonpath-plus": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.1.0.tgz",
-      "integrity": "sha512-gHfV1IYqH8uJHYVTs8BJX1XKy2/rR93+f8QQi0xhx95aCiXn1ettYAd5T+7FU6wfqyDoX/wy0pm/fL3jOKJ9Lg==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.2.0.tgz",
+      "integrity": "sha512-T9V+8iNYKFL2n2rF+w02LBOT2JjDnTjioaNFrxRy0Bv1y/hNsqR/EBK7Ojy2ythRHwmz2cRIls+9JitQGZC/sw==",
       "requires": {
-        "@jsep-plugin/assignment": "^1.2.1",
-        "@jsep-plugin/regex": "^1.0.3",
-        "jsep": "^1.3.9"
+        "@jsep-plugin/assignment": "^1.3.0",
+        "@jsep-plugin/regex": "^1.0.4",
+        "jsep": "^1.4.0"
       }
     },
     "JSONStream": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "ajv": "^8.12.0",
     "asl-path-validator": "^0.15.0",
     "commander": "^10.0.1",
-    "jsonpath-plus": "^10.0.0",
+    "jsonpath-plus": "^10.2.0",
     "yaml": "^2.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This bumps jsonpath-plus to ^10.2.0. This should address the [RCE vulnerability in JSONPath Plus](https://github.com/advisories/GHSA-pppg-cpfq-h7wr). This has already been addressed in the [asl-path-validator](https://github.com/massfords/asl-path-validator/blob/main/package.json#L53) dependency, which also has depends on jsonpath-plus.