### PR TITLE
fix: bump asl-path-validator to address math add validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.12.0",
-        "asl-path-validator": "^0.15.0",
+        "asl-path-validator": "^0.16.0",
         "commander": "^10.0.1",
         "jsonpath-plus": "^10.0.0",
         "yaml": "^2.3.1"
@@ -3073,9 +3073,10 @@
       }
     },
     "node_modules/asl-path-validator": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/asl-path-validator/-/asl-path-validator-0.15.0.tgz",
-      "integrity": "sha512-rIvxPZOu03VIyDSNkvrjkE8LQZFSCFLfsl43anCNjz/eEsIaCcydhbjyiNIx2dk7gKZ7LqYGeI/B3zWeaf+93Q==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/asl-path-validator/-/asl-path-validator-0.16.0.tgz",
+      "integrity": "sha512-mumubzzBfWIgnIcax+/f7yPW7l6JlR/B7qcM88NqVGwKnqvsGIwj99XsyarRpu4J81PN1NfE23/yQ8wOQClsig==",
+      "license": "MIT",
       "dependencies": {
         "jsonpath-plus": "^10.1.0"
       }
@@ -15011,9 +15012,9 @@
       "dev": true
     },
     "asl-path-validator": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/asl-path-validator/-/asl-path-validator-0.15.0.tgz",
-      "integrity": "sha512-rIvxPZOu03VIyDSNkvrjkE8LQZFSCFLfsl43anCNjz/eEsIaCcydhbjyiNIx2dk7gKZ7LqYGeI/B3zWeaf+93Q==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/asl-path-validator/-/asl-path-validator-0.16.0.tgz",
+      "integrity": "sha512-mumubzzBfWIgnIcax+/f7yPW7l6JlR/B7qcM88NqVGwKnqvsGIwj99XsyarRpu4J81PN1NfE23/yQ8wOQClsig==",
       "requires": {
         "jsonpath-plus": "^10.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "homepage": "https://github.com/ChristopheBougere/asl-validator#readme",
   "dependencies": {
     "ajv": "^8.12.0",
-    "asl-path-validator": "^0.15.0",
+    "asl-path-validator": "^0.16.0",
     "commander": "^10.0.1",
     "jsonpath-plus": "^10.0.0",
     "yaml": "^2.3.1"

--- a/src/__tests__/definitions/invalid-math-add.json
+++ b/src/__tests__/definitions/invalid-math-add.json
@@ -1,0 +1,14 @@
+{
+  "Comment": "MathAdd arguments must be paths or numbers",
+  "StartAt": "validate input",
+  "States": {
+    "validate input": {
+      "Type": "Pass",
+      "Parameters": {
+        "foo.$": "States.MathAdd(1,'-1')"
+      },
+      "ResultPath": "$.input",
+      "End": true
+    }
+  }
+}

--- a/src/__tests__/definitions/valid-math-add.json
+++ b/src/__tests__/definitions/valid-math-add.json
@@ -1,0 +1,14 @@
+{
+  "Comment": "MathAdd arguments must be paths or numbers",
+  "StartAt": "validate input",
+  "States": {
+    "validate input": {
+      "Type": "Pass",
+      "Parameters": {
+        "foo.$": "States.MathAdd(States.ArrayLength($$.Execution.Input.machines),-1)"
+      },
+      "ResultPath": "$.input",
+      "End": true
+    }
+  }
+}


### PR DESCRIPTION
chore: add positive and negative test cases
closes #165 