### PR TITLE
feat: add assign support for choice state

### DIFF
--- a/src/schemas/choice.json
+++ b/src/schemas/choice.json
@@ -307,6 +307,9 @@
             "properties": {
               "Next": {
                 "type": "string"
+              },
+              "Assign": {
+                "$ref": "jsonata.json#/definitions/assign"
               }
             },
             "required": ["Next"]
@@ -319,6 +322,9 @@
     },
     "Default": {
       "type": "string"
+    },
+    "Assign": {
+      "$ref": "jsonata.json#/definitions/assign"
     },
     "QueryLanguage": {
       "$ref": "jsonata.json#/definitions/queryLanguage"


### PR DESCRIPTION
According to [AWS](https://docs.aws.amazon.com/step-functions/latest/dg/workflow-variables.html#conceptual-overview-of-variables), `Choice` state also supports `Assign`:

> The following state types support Assign to declare and assign values to variables: Pass, Task, Map, Parallel, Choice, Wait.

I can use `Assign` in the default choice and in each choice in their editor:

<img width="1337" alt="image" src="https://github.com/user-attachments/assets/67cad249-ec07-4862-b843-b3e5a1b61627" />
