### PR TITLE
fix(jsonata): add JSONata syntax validation and support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "ajv": "^8.12.0",
         "asl-path-validator": "^0.16.1",
         "commander": "^10.0.1",
+        "jsonata": "^2.0.6",
         "jsonpath-plus": "^10.3.0",
         "yaml": "^2.3.1"
       },
@@ -6183,6 +6184,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsonata": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/jsonata/-/jsonata-2.0.6.tgz",
+      "integrity": "sha512-WhQB5tXQ32qjkx2GYHFw2XbL90u+LLzjofAYwi+86g6SyZeXHz9F1Q0amy3dWRYczshOC3Haok9J4pOCgHtwyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/jsonfile": {
@@ -17307,6 +17317,11 @@
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true
+    },
+    "jsonata": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/jsonata/-/jsonata-2.0.6.tgz",
+      "integrity": "sha512-WhQB5tXQ32qjkx2GYHFw2XbL90u+LLzjofAYwi+86g6SyZeXHz9F1Q0amy3dWRYczshOC3Haok9J4pOCgHtwyQ=="
     },
     "jsonfile": {
       "version": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "ajv": "^8.12.0",
     "asl-path-validator": "^0.16.1",
     "commander": "^10.0.1",
+    "jsonata": "^2.0.6",
     "jsonpath-plus": "^10.3.0",
     "yaml": "^2.3.1"
   },

--- a/src/__tests__/definitions/invalid-json-surround-syntax-extra-spaces.json
+++ b/src/__tests__/definitions/invalid-json-surround-syntax-extra-spaces.json
@@ -1,0 +1,12 @@
+{
+  "Comment": "JSONata Expressions shouldn't have extra spaces",
+  "StartAt": "X",
+  "States": {
+    "X": {
+      "Type": "Pass",
+      "Output": "{% \n10         %}",
+      "QueryLanguage": "JSONata",
+      "End": true
+    }
+  }
+}

--- a/src/__tests__/definitions/invalid-jsonata-surround-syntax-no-close.json
+++ b/src/__tests__/definitions/invalid-jsonata-surround-syntax-no-close.json
@@ -1,0 +1,12 @@
+{
+  "Comment": "JSONata Expressions should be surrounded like so: \"{% <JSONata expression> %}\"",
+  "StartAt": "X",
+  "States": {
+    "X": {
+      "Type": "Pass",
+      "Output": "{% 10 %",
+      "QueryLanguage": "JSONata",
+      "End": true
+    }
+  }
+}

--- a/src/__tests__/definitions/invalid-jsonata-surround-syntax-no-open.json
+++ b/src/__tests__/definitions/invalid-jsonata-surround-syntax-no-open.json
@@ -1,0 +1,12 @@
+{
+  "Comment": "JSONata Expressions should be surrounded like so: \"{% <JSONata expression> %}\"",
+  "StartAt": "X",
+  "States": {
+    "X": {
+      "Type": "Pass",
+      "Output": "10 %}",
+      "QueryLanguage": "JSONata",
+      "End": true
+    }
+  }
+}

--- a/src/__tests__/definitions/invalid-jsonata-surround-syntax-no-spaces.json
+++ b/src/__tests__/definitions/invalid-jsonata-surround-syntax-no-spaces.json
@@ -1,0 +1,12 @@
+{
+  "Comment": "JSONata Expressions should be surrounded like so: \"{% <JSONata expression> %}\"",
+  "StartAt": "X",
+  "States": {
+    "X": {
+      "Type": "Pass",
+      "Output": "{%10%}",
+      "QueryLanguage": "JSONata",
+      "End": true
+    }
+  }
+}

--- a/src/__tests__/definitions/invalid-jsonata-syntax-arithmetic.json
+++ b/src/__tests__/definitions/invalid-jsonata-syntax-arithmetic.json
@@ -1,0 +1,12 @@
+{
+  "Comment": "JSONata bad arithmetic error",
+  "StartAt": "X",
+  "States": {
+    "X": {
+      "Type": "Pass",
+      "Output": "{% 10 + * 2 %}",
+      "QueryLanguage": "JSONata",
+      "End": true
+    }
+  }
+}

--- a/src/__tests__/definitions/invalid-jsonata-syntax-jsonpath-in-jsonata-surround.json
+++ b/src/__tests__/definitions/invalid-jsonata-syntax-jsonpath-in-jsonata-surround.json
@@ -1,0 +1,12 @@
+{
+  "Comment": "JSONPath Syntax inside of a JSONata surround should not be valid",
+  "StartAt": "X",
+  "States": {
+    "X": {
+      "Type": "Pass",
+      "Output": "{% $.store.book[?(@.price < 10)].title %}",
+      "QueryLanguage": "JSONata",
+      "End": true
+    }
+  }
+}

--- a/src/__tests__/definitions/invalid-jsonata-syntax-mismatched-parens.json
+++ b/src/__tests__/definitions/invalid-jsonata-syntax-mismatched-parens.json
@@ -1,0 +1,12 @@
+{
+  "Comment": "Missing the closing paren on `sum` function call",
+  "StartAt": "X",
+  "States": {
+    "X": {
+      "Type": "Pass",
+      "Output": "{% $sum($states.input.items.numbers %",
+      "QueryLanguage": "JSONata",
+      "End": true
+    }
+  }
+}

--- a/src/__tests__/definitions/invalid-jsonata-syntax-variable-reference.json
+++ b/src/__tests__/definitions/invalid-jsonata-syntax-variable-reference.json
@@ -1,0 +1,12 @@
+{
+  "Comment": "JSONata Expressions should be surrounded like so: \"{% <JSONata expression> %}\"",
+  "StartAt": "X",
+  "States": {
+    "X": {
+      "Type": "Pass",
+      "Output": "{% $sum($states.input.items.numbers %",
+      "QueryLanguage": "JSONata",
+      "End": true
+    }
+  }
+}

--- a/src/__tests__/definitions/valid-json-surround-syntax.json
+++ b/src/__tests__/definitions/valid-json-surround-syntax.json
@@ -1,0 +1,12 @@
+{
+  "Comment": "JSONata Expressions should be surrounded like so: \"{% <JSONata expression> %}\"",
+  "StartAt": "X",
+  "States": {
+    "X": {
+      "Type": "Pass",
+      "Output": "{% 10 %}",
+      "QueryLanguage": "JSONata",
+      "End": true
+    }
+  }
+}

--- a/src/__tests__/definitions/valid-jsonata-syntax-function-call.json
+++ b/src/__tests__/definitions/valid-jsonata-syntax-function-call.json
@@ -1,0 +1,12 @@
+{
+  "Comment": "JSONata function calls",
+  "StartAt": "X",
+  "States": {
+    "X": {
+      "Type": "Pass",
+      "Output": "{% $sum($states.input.numbers) %}",
+      "QueryLanguage": "JSONata",
+      "End": true
+    }
+  }
+}

--- a/src/__tests__/definitions/valid-jsonata-syntax-path-expression.json
+++ b/src/__tests__/definitions/valid-jsonata-syntax-path-expression.json
@@ -1,0 +1,12 @@
+{
+  "Comment": "JSONata path expression",
+  "StartAt": "X",
+  "States": {
+    "X": {
+      "Type": "Pass",
+      "Output": "{% $states.input.data.items %}",
+      "QueryLanguage": "JSONata",
+      "End": true
+    }
+  }
+}

--- a/src/__tests__/definitions/valid-jsonata-syntax-simple-arithmetic.json
+++ b/src/__tests__/definitions/valid-jsonata-syntax-simple-arithmetic.json
@@ -1,0 +1,12 @@
+{
+  "Comment": "JSONata simple arithmetic",
+  "StartAt": "X",
+  "States": {
+    "X": {
+      "Type": "Pass",
+      "Output": "{% 1+2 %}",
+      "QueryLanguage": "JSONata",
+      "End": true
+    }
+  }
+}

--- a/src/checks/jsonata-syntax-validator.ts
+++ b/src/checks/jsonata-syntax-validator.ts
@@ -1,0 +1,78 @@
+import jsonata from "jsonata";
+import {
+  StateMachine,
+  StateMachineError,
+  StateMachineErrorCode,
+} from "../types";
+import { getStates } from "./get-states";
+
+type Value = string | number | boolean | Record<string, unknown>;
+
+function checkField(
+  stateName: string,
+  fieldName: string,
+  value: Value
+): StateMachineError[] {
+  if (typeof value === "object")
+    if (Array.isArray(value))
+      return value.flatMap((entry, index) =>
+        checkField(stateName, `${fieldName}[${index}]`, entry as Value)
+      );
+    else
+      Object.entries(value).flatMap(([innerFieldName, innerValue]) =>
+        checkField(
+          stateName,
+          fieldName + "/" + innerFieldName,
+          innerValue as Value
+        )
+      );
+  else if (typeof value === "string")
+    if (value.startsWith("{%") || value.endsWith("%}"))
+      if (/\{% .* %\}/.test(value)) {
+        try {
+          jsonata(value.match(/\{% (.*) %\}/)?.[1] ?? "");
+          return [];
+        } catch (error) {
+          return [
+            {
+              "Error code": StateMachineErrorCode.InvalidJsonataSyntax,
+              Message: `Invalid JSONata syntax in ${stateName}/${fieldName}: ${
+                (error as Error).message
+              }`,
+            },
+          ];
+        }
+      } else
+        return [
+          {
+            "Error code": StateMachineErrorCode.InvalidJsonataSyntax,
+            Message: `Invalid JSONata syntax in ${stateName}/${fieldName}: JSONata surround syntax incomplete. Should be: "{% <JSONata expression> %}"`,
+          },
+        ];
+    else return [];
+  else if (typeof value === "boolean") return [];
+  else if (typeof value === "number") return [];
+  // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+  else
+    throw Error(
+      `JSONata Syntax Validation Error: ${stateName}/${fieldName} is of type '${typeof value}' (${value}) which is not expected!`
+    );
+  return [];
+}
+
+export function validateJsonataSyntax(
+  definition: StateMachine
+): StateMachineError[] {
+  return getStates(definition.States)
+    .filter(
+      (entry) =>
+        (entry.state.QueryLanguage ??
+          definition.QueryLanguage ??
+          "JSONPath") === "JSONata"
+    )
+    .flatMap(({ state, stateName }) =>
+      Object.entries(state).flatMap(([fieldName, value]) =>
+        checkField(stateName, fieldName, value as Value)
+      )
+    );
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,7 @@ export enum StateMachineErrorCode {
   FailCauseProperty = "FAIL_CAUSE_PROPERTY",
   FailErrorProperty = "FAIL_ERROR_PROPERTY",
   QueryLanguageFieldError = "QUERY_LANGUAGE_FIELD",
+  InvalidJsonataSyntax = "INVALID_JSONATA_SYNTAX",
 }
 export type StateMachineError = {
   "Error code": StateMachineErrorCode;

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -25,6 +25,7 @@ import {
   stateChecks,
 } from "./checks/state-checks";
 import { StateEntry } from "./checks/get-states";
+import { validateJsonataSyntax } from "./checks/jsonata-syntax-validator";
 
 const DefaultOptions: ValidationOptions = {
   checkPaths: true,
@@ -63,6 +64,7 @@ export = function validator(
     errors.push(
       ...mustNotHaveDuplicateFieldNamesAfterEvaluation(definition, options)
     );
+    errors.push(...validateJsonataSyntax(definition));
     errors.push(
       ...stateChecks(definition, options, [
         {


### PR DESCRIPTION
- Introduced JSONata syntax validation in the validator.
- Added new error code for invalid JSONata syntax.
- Included 'jsonata' dependency.
- Created a handfull of simple tests.

CLOSES ChristopheBougere/asl-validator#171